### PR TITLE
ISO 8859-1 instead of ansi

### DIFF
--- a/src/sharkadm/config/import_matrix.py
+++ b/src/sharkadm/config/import_matrix.py
@@ -59,7 +59,7 @@ class ImportMatrixConfig:
     def __init__(self,
                  path: str | pathlib.Path,
                  data_type: str = None,
-                 encoding: str = 'ansi') -> None:
+                 encoding: str = 'iso_8859_1') -> None:
                  # data_type_mapper: DataTypeMapper = None) -> None:
         self._path = pathlib.Path(path)
         # self._data_type = data_type_mapper.get(data_type)


### PR DESCRIPTION
The "ansi" encoding is only available on the Windows platform.

A more thorough fix could be to expose the encoding parameter all the way out to `get_row_data_from_lims_export()`.

Part of #43