### PR TITLE
Remove linting rul for __init__.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,5 @@ select = [
     "I",  # isort: unsorted-imports
     "RUF"  # Ruff-specific rules
 ]
+
+per-file-ignores."__init__.py" = ["F401"]

--- a/src/sharkadm/data/__init__.py
+++ b/src/sharkadm/data/__init__.py
@@ -1,5 +1,3 @@
-# ruff: noqa: F401
-
 import functools
 import inspect
 import logging

--- a/src/sharkadm/data/archive/__init__.py
+++ b/src/sharkadm/data/archive/__init__.py
@@ -1,4 +1,3 @@
-# ruff: noqa: F401
 import os
 import pathlib
 from typing import Union

--- a/src/sharkadm/data/df/__init__.py
+++ b/src/sharkadm/data/df/__init__.py
@@ -1,4 +1,3 @@
-# ruff: noqa: F401
 from sharkadm.data.df.df_data_holder import (
     PandasDataFrameDataHolder,
     PolarsDataFrameDataHolder,

--- a/src/sharkadm/exporters/__init__.py
+++ b/src/sharkadm/exporters/__init__.py
@@ -1,4 +1,3 @@
-# ruff: noqa: F401
 # ruff: noqa: I001
 import functools
 import pathlib

--- a/src/sharkadm/multi_transformers/__init__.py
+++ b/src/sharkadm/multi_transformers/__init__.py
@@ -1,4 +1,3 @@
-# ruff: noqa: F401
 import functools
 import pathlib
 from typing import Type

--- a/src/sharkadm/transformers/__init__.py
+++ b/src/sharkadm/transformers/__init__.py
@@ -1,4 +1,3 @@
-# ruff: noqa: F401
 # ruff: noqa: I001
 import functools
 import pathlib

--- a/src/sharkadm/validators/__init__.py
+++ b/src/sharkadm/validators/__init__.py
@@ -3,46 +3,28 @@ import pathlib
 from typing import Type
 
 from sharkadm import utils
-from sharkadm.utils.inspect_kwargs import get_kwargs_for_class as get_kwargs_for_class
+from sharkadm.utils.inspect_kwargs import get_kwargs_for_class
 from sharkadm.validators.aphia_id import (
-    ValidateAphiaIdVsBvolAphiaId as ValidateAphiaIdVsBvolAphiaId,
+    ValidateAphiaIdVsBvolAphiaId,
+    ValidateReportedVsAphiaId,
+    ValidateReportedVsBvolAphiaId,
 )
-from sharkadm.validators.aphia_id import (
-    ValidateReportedVsAphiaId as ValidateReportedVsAphiaId,
-)
-from sharkadm.validators.aphia_id import (
-    ValidateReportedVsBvolAphiaId as ValidateReportedVsBvolAphiaId,
-)
-from sharkadm.validators.base import Validator as Validator
+from sharkadm.validators.base import Validator
 from sharkadm.validators.column_combination import (
-    AssertCombination as AssertCombination,
+    AssertCombination,
+    AssertMinMaxDepthCombination,
 )
-from sharkadm.validators.column_combination import (
-    AssertMinMaxDepthCombination as AssertMinMaxDepthCombination,
-)
-from sharkadm.validators.columns import (
-    ValidateColumnViewColumnsNotInDataset as ValidateColumnViewColumnsNotInDataset,
-)
-from sharkadm.validators.common_values import (
-    ValidateCommonValuesByVisit as ValidateCommonValuesByVisit,
-)
-from sharkadm.validators.date_and_time import MissingTime as MissingTime
+from sharkadm.validators.columns import ValidateColumnViewColumnsNotInDataset
+from sharkadm.validators.common_values import ValidateCommonValuesByVisit
+from sharkadm.validators.date_and_time import MissingTime
 from sharkadm.validators.mandatory import (
-    ValidateValuesInMandatoryNatColumns as ValidateValuesInMandatoryNatColumns,
+    ValidateValuesInMandatoryNatColumns,
+    ValidateValuesInMandatoryRegColumns,
 )
-from sharkadm.validators.mandatory import (
-    ValidateValuesInMandatoryRegColumns as ValidateValuesInMandatoryRegColumns,
-)
-from sharkadm.validators.occurrence_id import (
-    ValidateOccurrenceId as ValidateOccurrenceId,
-)
-from sharkadm.validators.position import (
-    CheckIfLatLonIsSwitched as CheckIfLatLonIsSwitched,
-)
-from sharkadm.validators.positive import (
-    ValidatePositiveValues as ValidatePositiveValues,
-)
-from sharkadm.validators.year import ValidateYearNrDigits as ValidateYearNrDigits
+from sharkadm.validators.occurrence_id import ValidateOccurrenceId
+from sharkadm.validators.position import CheckIfLatLonIsSwitched
+from sharkadm.validators.positive import ValidatePositiveValues
+from sharkadm.validators.year import ValidateYearNrDigits
 
 
 @functools.cache

--- a/src/sharkadm/validators/station/__init__.py
+++ b/src/sharkadm/validators/station/__init__.py
@@ -1,0 +1,8 @@
+from sharkadm.validators.station.coordinates_dm import ValidateCoordinatesDm
+from sharkadm.validators.station.coordinates_sweref99 import ValidateCoordinatesSweref99
+from sharkadm.validators.station.name_in_master import ValidateNameInMaster
+from sharkadm.validators.station.position_in_ocean import ValidatePositionInOcean
+from sharkadm.validators.station.position_within_station_radius import (
+    ValidatePositionWithinStationRadius,
+)
+from sharkadm.validators.station.synonym_in_master import ValidateSynonymsInMaster


### PR DESCRIPTION
Removing rule F401 for all __init__.py files to allow module import configurations without the need for verbose import aliases.