### PR TITLE
replace nan with none

### DIFF
--- a/src/sharkadm/transformers/__init__.py
+++ b/src/sharkadm/transformers/__init__.py
@@ -205,7 +205,10 @@ from sharkadm.transformers.remove import (
     RemoveValuesInColumns,
     SetMaxLengthOfValuesInColumns,
 )
-from sharkadm.transformers.replace import ReplaceNanWithEmptyString
+from sharkadm.transformers.replace import (
+    ReplaceNanWithEmptyString,
+    PolarsReplaceNanWithNone,
+)
 from sharkadm.transformers.replace_comma_with_dot import (
     PolarsReplaceCommaWithDot,
     ReplaceCommaWithDot,

--- a/src/sharkadm/transformers/replace.py
+++ b/src/sharkadm/transformers/replace.py
@@ -1,4 +1,6 @@
-from .base import DataHolderProtocol, Transformer
+from sharkadm.sharkadm_logger import adm_logger
+
+from .base import DataHolderProtocol, PolarsTransformer, Transformer
 
 
 class ReplaceNanWithEmptyString(Transformer):
@@ -8,3 +10,17 @@ class ReplaceNanWithEmptyString(Transformer):
 
     def _transform(self, data_holder: DataHolderProtocol) -> None:
         data_holder.data.fillna("", inplace=True)
+
+
+class PolarsReplaceNanWithNone(PolarsTransformer):
+    @staticmethod
+    def get_transformer_description() -> str:
+        return "Replaces all nan values in data with None"
+
+    def _transform(self, data_holder: DataHolderProtocol) -> None:
+        if not data_holder.data.is_empty():
+            data_holder.data = data_holder.data.fill_nan(None)
+        else:
+            adm_logger.log_transformation(
+                "No data in data holder", level=adm_logger.WARNING
+            )

--- a/tests/transformers/test_add_density.py
+++ b/tests/transformers/test_add_density.py
@@ -10,13 +10,9 @@ from sharkadm.transformers.add_density import PolarsAddDensity, PolarsAddDensity
     "given_visit_key, given_latitude, given_longitude, given_depths, "
     "given_salinity_psu, given_temperature, expected_success",
     (
-        ("ABC123", 58.2, 10.1, 5.0, -7, 20, False),
-        ("ABC123", 58.2, 10.1, 10.1, 35.2, -1.7, True),
-        ("DEF456", 57.1, 11.0, 5.7, 0, 5.2, True),
-        ("DEF456", 57.1, 11.0, 15.2, 5.2, 10.1, True),
-        ("GHJ789", 56.5, 12.0, -100, 10.3, 10.1, False),
-        ("GHJ789", 56.5, 12.0, 100.0, 20.8, 34, True),
-        ("GHJ789", 56.5, 12.0, 500.2, 33.2, 20.1, True),
+        ("ABC123", 58.2, 10.1, 5.0, -7, 20, False),  # erroneous salinity
+        ("DEF456", 57.1, 11.0, 5.7, 0, 5.2, True),  # ok data
+        ("GHJ789", 56.5, 12.0, -100, 10.3, 10.1, False),  # erroneous depth
     ),
 )
 @patch("sharkadm.config.get_all_data_types", return_value=[])
@@ -84,7 +80,7 @@ def test_validate_add_density_wide(
             ["Salinity CTD", "Temperature CTD"],
             [-10.0, -1.7],
             False,
-        ),
+        ),  # erroneous salinity
         (
             ["DEF456", "DEF456"],
             [57.1, 57.1],
@@ -93,7 +89,7 @@ def test_validate_add_density_wide(
             ["Salinity CTD", "Temperature CTD"],
             [35.2, 10.1],
             True,
-        ),
+        ),  # ok data
     ),
 )
 @patch("sharkadm.config.get_all_data_types", return_value=[])

--- a/tests/transformers/test_replace.py
+++ b/tests/transformers/test_replace.py
@@ -1,0 +1,142 @@
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import pytest
+
+from sharkadm.transformers.replace import (
+    PolarsReplaceNanWithNone,
+    ReplaceNanWithEmptyString,
+)
+
+
+@pytest.mark.parametrize(
+    "given_visit_key, given_latitude, given_longitude, given_depths, "
+    "given_parameter, given_value, expected_empty_strings",
+    (
+        ("ABC123", 57.3, 10.1, 5.0, "PHOS", np.nan, 1),  # example data with nan values
+        ("ABC123", 58.2, np.nan, 7.3, "PTOT", np.nan, 2),  # example data with nan values
+    ),
+)
+@patch("sharkadm.config.get_all_data_types", return_value=[])
+def test_validate_replace_nan_with_empty_string(
+    mocked_data_types,
+    pandas_data_frame_holder_class,
+    given_visit_key,
+    given_latitude,
+    given_longitude,
+    given_depths,
+    given_parameter,
+    given_value,
+    expected_empty_strings,
+):
+    # Arrange
+    given_data = pd.DataFrame(
+        {
+            "visit_key": [given_visit_key],
+            "sample_latitude_dd": [given_latitude],
+            "sample_longitude_dd": [given_longitude],
+            "sample_depth_m": [given_depths],
+            "parameter": [given_parameter],
+            "value": [given_value],
+        }
+    )
+
+    # Given a valid data holder
+    given_data_holder = pandas_data_frame_holder_class(given_data)
+    mocked_data_types.side_effect = (given_data_holder.data_type_internal,)
+
+    # There should be nan values in the dataframe
+    # before application of transformer
+    assert given_data_holder.data.isna().values.any(), (
+        "There are no nan values in the dataframe"
+    )
+
+    # Transforming the data
+    ReplaceNanWithEmptyString().transform(given_data_holder)
+
+    # After transformation there should be no nan values
+    # in the dataframe
+    assert not given_data_holder.data.isna().values.any(), (
+        "There are still nan values in the dataframe"
+    )
+
+    # The number of None in the dataframe should match the expected value
+    assert expected_empty_strings == (given_data_holder.data == "").sum().sum(), (
+        "The number of fields with empty string do not match the expected value"
+    )
+
+
+@pytest.mark.parametrize(
+    "given_visit_key, given_latitude, given_longitude, given_depths, "
+    "given_parameter, given_value, expected_none",
+    (
+        ("ABC123", 57.3, 10.1, 5.0, "PHOS", np.nan, 1),  # example data with nan values
+        ("ABC123", 58.2, np.nan, 7.3, "PTOT", np.nan, 2),  # example data with nan values
+    ),
+)
+@patch("sharkadm.config.get_all_data_types", return_value=[])
+def test_validate_polars_replace_nan_with_none(
+    mocked_data_types,
+    polars_data_frame_holder_class,
+    given_visit_key,
+    given_latitude,
+    given_longitude,
+    given_depths,
+    given_parameter,
+    given_value,
+    expected_none,
+):
+    # Arrange
+    given_data = pl.DataFrame(
+        {
+            "visit_key": given_visit_key,
+            "sample_latitude_dd": given_latitude,
+            "sample_longitude_dd": given_longitude,
+            "sample_depth_m": given_depths,
+            "parameter": given_parameter,
+            "value": given_value,
+        }
+    )
+
+    # Given a valid data holder
+    given_data_holder = polars_data_frame_holder_class(given_data)
+    mocked_data_types.side_effect = (given_data_holder.data_type_internal,)
+
+    # There should be nan values in the dataframe
+    # before application of transformer
+    number_of_nans_in_data_holder = 0
+    for col in given_data_holder.data.columns:
+        try:
+            number_of_nans_in_data_holder += given_data_holder.data.select(
+                pl.col(col).cast(pl.Float64).is_nan().sum()
+            ).row(0)[0]
+        except Exception:
+            pass
+
+    assert number_of_nans_in_data_holder > 0, "There are no nan values in the dataframe"
+
+    # Transforming the data
+    PolarsReplaceNanWithNone().transform(given_data_holder)
+
+    number_of_nans_in_data_holder = 0
+    for col in given_data_holder.data.columns:
+        try:
+            number_of_nans_in_data_holder += given_data_holder.data.select(
+                pl.col(col).cast(pl.Float64).is_nan().sum()
+            ).row(0)[0]
+        except Exception:
+            pass
+
+    # After transformation there should be no nan values
+    # in the dataframe
+    assert number_of_nans_in_data_holder == 0, (
+        "There are still nan values in the dataframe"
+    )
+
+    # The number of None in the dataframe should match the expected value
+    assert (
+        expected_none
+        == given_data_holder.data.null_count().select(pl.all()).to_numpy().sum()
+    ), "The number of fields with None do not match the expected value"


### PR DESCRIPTION
Här kommer en transformer som ersätter nan värden med None för att vara mer polars kompatibelt. transformern har lagts till i replace.py som redan fanns där nan ersätts med "" mot pandas. Ia och jag har gjort ett pytest till replace.py som fungerar mot båda transformer klasserna i replace.py. vi valde att inte göra en polars version av nan till "" då vi tror att det kan ställa till det:).