### PR TITLE
Removed stray prints

### DIFF
--- a/src/sharkadm/exporters/dataframe.py
+++ b/src/sharkadm/exporters/dataframe.py
@@ -123,8 +123,7 @@ class PolarsDataFrame(PolarsExporter):
                                 item=col,
                                 level=adm_logger.WARNING,
                             )
-                        print(f"{value=}")
-                        print(f"{new_value=}")
+
                         df = df.with_columns(
                             pl.when(pl.col(col) == value)
                             .then(pl.lit(new_value))

--- a/src/sharkadm/multi_transformers/base.py
+++ b/src/sharkadm/multi_transformers/base.py
@@ -154,13 +154,6 @@ class PolarsMultiTransformer(Transformer):
         return self.get_transformer_description()
 
     def transform(self, data_holder: "PolarsDataHolder") -> None:
-        print("¤¤¤")
-        print(
-            config.get_valid_data_types(
-                valid=self.valid_data_types, invalid=self.invalid_data_types
-            )
-        )
-        print()
         if (
             data_holder.data_type_internal != "unknown"
             and data_holder.data_type_internal
@@ -184,14 +177,7 @@ class PolarsMultiTransformer(Transformer):
                 f" {self.__class__.__name__}"
             )
             return
-        # if data_holder.__class__.__name__ not in get_valid_data_holders(
-        #     valid=self.valid_data_holders, invalid=self.invalid_data_holders
-        # ):
-        #     adm_logger.log_workflow(
-        #         f"Invalid data_holder {data_holder.__class__.__name__} "
-        #         f"for multi transformer {self.__class__.__name__}"
-        #     )
-        #     return
+
         if data_holder.data_structure.lower() not in config.get_valid_data_structures(
             valid=self.invalid_data_structures, invalid=self.invalid_data_structures
         ):
@@ -209,7 +195,6 @@ class PolarsMultiTransformer(Transformer):
         )
         t0 = time.time()
         for trans in self._transformers:
-            print(f"{trans=}")
             trans().transform(data_holder=data_holder)
         adm_logger.log_workflow(
             f"Multi transformer {self.__class__.__name__} executed "

--- a/src/sharkadm/sharkadm_logger/sharkadm_logger.py
+++ b/src/sharkadm/sharkadm_logger/sharkadm_logger.py
@@ -388,7 +388,6 @@ class SHARKadmLogger:
         levels = self._get_levels(*args, levels=levels)
         purposes = self._get_purposes(*args, purposes=purposes)
 
-        print(f"{levels=}")
         self._filtered_levels = levels
         self._filtered_purposes = purposes
         self._filtered_log_types = log_types


### PR DESCRIPTION
When using SHARKadm downstream, some stray prints from SHARKadm are cluttering the output. If these are still wanted, they are better implemented as log messages.